### PR TITLE
ViT and U-Net hotfixes

### DIFF
--- a/src/climate_learn/models/components/linear.py
+++ b/src/climate_learn/models/components/linear.py
@@ -40,8 +40,9 @@ class Linear(nn.Module):
 
     def rollout(
         self,
-        x,
-        y,
+        x: torch.Tensor,
+        y: torch.Tensor,
+        clim,
         variables,
         out_variables,
         steps,
@@ -50,6 +51,9 @@ class Linear(nn.Module):
         lat,
         log_steps,
         log_days,
+        mean_transform,
+        std_transform,
+        log_day,
     ):
         # transform: get back to the original range
         if steps > 1:

--- a/src/climate_learn/models/components/unet.py
+++ b/src/climate_learn/models/components/unet.py
@@ -36,6 +36,7 @@ class Unet(nn.Module):
         n_samples: int = 50,  # only used for mcdropout
     ) -> None:
         super().__init__()
+        self.prob_type = None
         self.in_channels = in_channels
         if out_channels is None:
             out_channels = in_channels
@@ -102,7 +103,7 @@ class Unet(nn.Module):
             activation=activation,
             norm=norm,
             dropout=dropout,
-            mc_dropout=mc_dropout,
+            mc_dropout=(self.prob_type == "mcdropout"),
         )
 
         # #### Second half of U-Net - increasing resolution
@@ -305,6 +306,12 @@ class Unet(nn.Module):
                 ],
                 x,
             )
+
+    def val_rollout(self, *args, **kwargs):
+        return self.rollout(*args, **kwargs)
+
+    def test_rollout(self, *args, **kwargs):
+        return self.rollout(*args, **kwargs)
 
     def upsample(self, x, y, out_vars, transform, metric):
         with torch.no_grad():

--- a/src/climate_learn/models/components/utils/pos_embed.py
+++ b/src/climate_learn/models/components/utils/pos_embed.py
@@ -23,8 +23,8 @@ def get_2d_sincos_pos_embed(embed_dim, grid_size_h, grid_size_w, cls_token=False
     return:
     pos_embed: [grid_size*grid_size, embed_dim] or [1+grid_size*grid_size, embed_dim] (w/ or w/o cls_token)
     """
-    grid_h = np.arange(grid_size_h, dtype=np.float32)
-    grid_w = np.arange(grid_size_w, dtype=np.float32)
+    grid_h = np.arange(grid_size_h, dtype=float)
+    grid_w = np.arange(grid_size_w, dtype=float)
     grid = np.meshgrid(grid_w, grid_h)  # here w goes first
     grid = np.stack(grid, axis=0)
 
@@ -53,7 +53,7 @@ def get_1d_sincos_pos_embed_from_grid(embed_dim, pos):
     out: (M, D)
     """
     assert embed_dim % 2 == 0
-    omega = np.arange(embed_dim // 2, dtype=np.float)
+    omega = np.arange(embed_dim // 2, dtype=float)
     omega /= embed_dim / 2.0
     omega = 1.0 / 10000**omega  # (D/2,)
 

--- a/src/climate_learn/models/components/vit.py
+++ b/src/climate_learn/models/components/vit.py
@@ -39,6 +39,8 @@ class VisionTransformer(nn.Module):
     ):
         super().__init__()
 
+        self.prob_type = None
+
         self.img_size = img_size
         self.upsampling = upsampling
         self.img_out_size = [img_size[0] * upsampling, img_size[1] * upsampling]
@@ -182,12 +184,16 @@ class VisionTransformer(nn.Module):
         return ([m(pred, y, out_variables, lat=lat) for m in metric], pred)
 
     def forward(self, x, y, out_variables, metric, lat):
+        if len(x.shape) == 5:  # history
+            x = x.flatten(1, 2)
         embeddings = self.forward_encoder(x)  # B, L, D
         preds = self.head(embeddings)
         loss, preds = self.forward_loss(y, preds, out_variables, metric, lat)
         return loss, preds
 
     def predict(self, x):
+        if len(x.shape) == 5:  # history
+            x = x.flatten(1, 2)
         with torch.no_grad():
             embeddings = self.forward_encoder(x)
             pred = self.head(embeddings)
@@ -195,8 +201,8 @@ class VisionTransformer(nn.Module):
 
     def rollout(
         self,
-        x,
-        y,
+        x: torch.Tensor,
+        y: torch.Tensor,
         clim,
         variables,
         out_variables,
@@ -206,6 +212,9 @@ class VisionTransformer(nn.Module):
         lat,
         log_steps,
         log_days,
+        mean_transform,
+        std_transform,
+        log_day,
     ):
         preds = []
         for _ in range(steps):
@@ -231,6 +240,12 @@ class VisionTransformer(nn.Module):
             ],
             x,
         )
+
+    def val_rollout(self, *args, **kwargs):
+        return self.rollout(*args, **kwargs)
+
+    def test_rollout(self, *args, **kwargs):
+        return self.rollout(*args, **kwargs)
 
     def upsample(self, x, y, out_vars, transform, metric):
         with torch.no_grad():


### PR DESCRIPTION
Hotfix so that ViT and U-Net models can be instantiated.

For ViT, try the following keyword arguments:
```python
model_kwargs = {
    "in_vars": ["2m_temperature"],
    "out_vars": ["2m_temperature"],
    "img_size": [32, 64]
}
```

For U-Net, try the following keyword arguments:
```python
model_kwargs = {
    "in_channels": len(data_module.hparams.in_vars),
    "out_channels": len(data_module.hparams.out_vars),
    "n_blocks": 4
}
```