### PR TITLE
Standardize

### DIFF
--- a/src/climate_learn/models/components/unet.py
+++ b/src/climate_learn/models/components/unet.py
@@ -167,54 +167,24 @@ class Unet(nn.Module):
 
         return pred
 
-    def forward(self, x: torch.Tensor, y: torch.Tensor, out_variables, metric, lat):
+    def forward(
+        self, x: torch.Tensor, y: torch.Tensor, out_variables, metric, lat, log_postfix
+    ):
         # B, C, H, W
         pred = self.predict(x)
-        return ([m(pred, y, out_variables, lat=lat) for m in metric], x)
-
-    def rollout(
-        self,
-        x: torch.Tensor,
-        y: torch.Tensor,
-        clim,
-        variables,
-        out_variables,
-        steps,
-        metric,
-        transform,
-        lat,
-        log_steps,
-        log_days,
-    ):
-        if steps > 1:
-            assert len(variables) == len(out_variables)
-
-        preds = []
-        for _ in range(steps):
-            x = self.predict(x)
-            preds.append(x)
-        preds = torch.stack(preds, dim=1)
-        if len(y.shape) == 4:
-            y = y.unsqueeze(1)
-
         return (
             [
-                m(
-                    preds,
-                    y,
-                    out_variables,
-                    transform=transform,
-                    lat=lat,
-                    log_steps=log_steps,
-                    log_days=log_days,
-                    clim=clim,
-                )
+                m(pred, y, out_variables, lat=lat, log_postfix=log_postfix)
                 for m in metric
             ],
             x,
         )
 
-    def upsample(self, x, y, out_vars, transform, metric):
-        with torch.no_grad():
-            pred = self.predict(x)
-        return ([m(pred, y, out_vars, transform=transform) for m in metric], x)
+    def evaluate(
+        self, x, y, variables, out_variables, transform, metrics, lat, clim, log_postfix
+    ):
+        pred = self.predict(x)
+        return [
+            m(pred, y, transform, out_variables, lat, clim, log_postfix)
+            for m in metrics
+        ], pred

--- a/src/climate_learn/models/modules/downscale.py
+++ b/src/climate_learn/models/modules/downscale.py
@@ -61,7 +61,9 @@ class DownscaleLitModule(LightningModule):
         x, y, _, out_variables = batch
         x = interpolate_input(x, y)
 
-        loss_dict, _ = self.net.forward(x, y, out_variables, [mse], lat=self.lat)
+        loss_dict, _ = self.net.forward(
+            x, y, out_variables, [mse], lat=self.lat, log_postfix=""
+        )
         loss_dict = loss_dict[0]
         for var in loss_dict.keys():
             self.log(
@@ -78,8 +80,16 @@ class DownscaleLitModule(LightningModule):
         x, y, variables, out_variables = batch
         x = interpolate_input(x, y)
 
-        all_loss_dicts, _ = self.net.upsample(
-            x, y, out_variables, self.denormalization, [rmse, pearson, mean_bias]
+        all_loss_dicts, _ = self.net.evaluate(
+            x,
+            y,
+            variables,
+            out_variables,
+            self.denormalization,
+            [rmse, pearson, mean_bias],
+            self.lat,
+            self.val_clim,
+            log_postfix="",
         )
         loss_dict = {}
         for d in all_loss_dicts:
@@ -102,8 +112,16 @@ class DownscaleLitModule(LightningModule):
         x, y, variables, out_variables = batch
         x = interpolate_input(x, y)
 
-        all_loss_dicts, _ = self.net.upsample(
-            x, y, out_variables, self.denormalization, [rmse, pearson, mean_bias]
+        all_loss_dicts, _ = self.net.evaluate(
+            x,
+            y,
+            variables,
+            out_variables,
+            self.denormalization,
+            [rmse, pearson, mean_bias],
+            self.lat,
+            self.test_clim,
+            log_postfix="",
         )
         loss_dict = {}
         for d in all_loss_dicts:


### PR DESCRIPTION
An effort to clean and standardize the code:
1. Instead of having a `rollout` function and an `upsample` function, we now have a unified `evaluation` function used for evaluating models.
2. Standardize the shape of the prediction to [B, C, H, W]. This is consistent with all metrics and losses.
3. Remove redundant code in forecasting and downscaling Module classes, and make changes to adhere to changes in model components and metrics.