### PR TITLE
Made args in create_copy optional

### DIFF
--- a/src/climate_learn/data/climate_dataset/args/climate_dataset_args.py
+++ b/src/climate_learn/data/climate_dataset/args/climate_dataset_args.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
 
 
 class ClimateDatasetArgs(ABC):
+    r"""Data class that stores necessary arguments to initialize the abstract :py:class:`~climate_learn.data.climate_dataset.ClimateDataset`"""
     _data_class: Union[Callable[..., ClimateDataset], str] = "ClimateDataset"
 
     def __init__(
@@ -18,12 +19,37 @@ class ClimateDatasetArgs(ABC):
         constants: Sequence[str] = [],
         split: str = "train",
     ) -> None:
+        r"""
+        .. highlight:: python
+
+        :param variables: List of variables for which the Climate Dataset should support queries
+        :type variables: Sequence[str]
+        :param constants: List of constants for which the Climate Dataset should support queries
+        :type constants: Sequence[str]
+        :param split: The name of the split correpsonding to which the Climate Dataset would load
+            the data for. Supported name for splits include `['train', 'val', 'test']`
+        :type split: str
+        """
         self.variables: Sequence[str] = variables
         self.constants: Sequence[str] = constants
         self.split: str = split
         ClimateDatasetArgs.check_validity(self)
 
-    def create_copy(self, args: Dict[str, Any]) -> ClimateDatasetArgs:
+    def create_copy(self, args: Dict[str, Any] = {}) -> ClimateDatasetArgs:
+        r"""
+        Returns a near identical copy of the current instance of the class.
+            Useful for cases when need to create an almost identical copy of the
+            current instance of the class but with few changes. The changes are
+            passed by args, which is a dict. The keys of this dict should be the
+            attribute name and value should be the new value for the corresponding 
+            attribute.
+
+        .. highlight:: python
+        
+        :param args: A dict whose keys are the attribute names and values are the 
+            new value for the corresponding attribute.
+        :type args: Dict[str, Any]
+        """
         new_instance: ClimateDatasetArgs = copy.deepcopy(self)
         for arg in args:
             if hasattr(new_instance, arg):
@@ -32,6 +58,9 @@ class ClimateDatasetArgs(ABC):
         return new_instance
 
     def check_validity(self) -> None:
+        r"""
+        Checks whether the attributes of the current instance of class hold legal values.
+        """
         if self.split not in ["train", "val", "test"]:
             raise RuntimeError(
                 f"Split {self.split} is not recognized! "

--- a/src/climate_learn/data/climate_dataset/args/climate_dataset_args.py
+++ b/src/climate_learn/data/climate_dataset/args/climate_dataset_args.py
@@ -41,12 +41,12 @@ class ClimateDatasetArgs(ABC):
             Useful for cases when need to create an almost identical copy of the
             current instance of the class but with few changes. The changes are
             passed by args, which is a dict. The keys of this dict should be the
-            attribute name and value should be the new value for the corresponding 
+            attribute name and value should be the new value for the corresponding
             attribute.
 
         .. highlight:: python
-        
-        :param args: A dict whose keys are the attribute names and values are the 
+
+        :param args: A dict whose keys are the attribute names and values are the
             new value for the corresponding attribute.
         :type args: Dict[str, Any]
         """

--- a/src/climate_learn/data/climate_dataset/args/stacked_climate_dataset_args.py
+++ b/src/climate_learn/data/climate_dataset/args/stacked_climate_dataset_args.py
@@ -20,7 +20,7 @@ class StackedClimateDatasetArgs(ClimateDatasetArgs):
         self.split: str = data_args[0].split
         StackedClimateDatasetArgs.check_validity(self)
 
-    def create_copy(self, args: Dict[str, Any]) -> StackedClimateDatasetArgs:
+    def create_copy(self, args: Dict[str, Any] = {}) -> StackedClimateDatasetArgs:
         new_instance: StackedClimateDatasetArgs = copy.deepcopy(self)
         for arg in args:
             if arg == "child_data_args":

--- a/src/climate_learn/data/dataset/args/map_dataset_args.py
+++ b/src/climate_learn/data/dataset/args/map_dataset_args.py
@@ -21,7 +21,7 @@ class MapDatasetArgs(ABC):
         self.climate_dataset_args: ClimateDatasetArgs = climate_dataset_args
         self.task_args: TaskArgs = task_args
 
-    def create_copy(self, args: Dict[str, Any]) -> MapDatasetArgs:
+    def create_copy(self, args: Dict[str, Any] = {}) -> MapDatasetArgs:
         new_instance: MapDatasetArgs = copy.deepcopy(self)
         for arg in args:
             if arg == "climate_dataset_args":

--- a/src/climate_learn/data/dataset/args/shard_dataset_args.py
+++ b/src/climate_learn/data/dataset/args/shard_dataset_args.py
@@ -25,7 +25,7 @@ class ShardDatasetArgs(ABC):
         self.task_args: TaskArgs = task_args
         self.n_chunks: int = n_chunks
 
-    def create_copy(self, args: Dict[str, Any]) -> ShardDatasetArgs:
+    def create_copy(self, args: Dict[str, Any] = {}) -> ShardDatasetArgs:
         new_instance: ShardDatasetArgs = copy.deepcopy(self)
         for arg in args:
             if arg == "climate_dataset_args":

--- a/src/climate_learn/data/task/args/task_args.py
+++ b/src/climate_learn/data/task/args/task_args.py
@@ -25,7 +25,7 @@ class TaskArgs(ABC):
         self.subsample: int = subsample
         TaskArgs.check_validity(self)
 
-    def create_copy(self, args: Dict[str, Any]) -> TaskArgs:
+    def create_copy(self, args: Dict[str, Any] = {}) -> TaskArgs:
         new_instance: TaskArgs = copy.deepcopy(self)
         for arg in args:
             if hasattr(new_instance, arg):


### PR DESCRIPTION
I realized that args in `create_copy()` of [`TaskArgs`](https://github.com/aditya-grover/climate-learn/blob/d298a0b096f8c1bd2e339f34017300dc14ea4a54/src/climate_learn/data/task/args/task_args.py#L28), [`ClimateDatasetArgs`](https://github.com/aditya-grover/climate-learn/blob/d298a0b096f8c1bd2e339f34017300dc14ea4a54/src/climate_learn/data/climate_dataset/args/climate_dataset_args.py#L26), [`MapDatasetArgs`](https://github.com/aditya-grover/climate-learn/blob/d298a0b096f8c1bd2e339f34017300dc14ea4a54/src/climate_learn/data/dataset/args/map_dataset_args.py#L24), [`ShardDatasetArgs`](https://github.com/aditya-grover/climate-learn/blob/d298a0b096f8c1bd2e339f34017300dc14ea4a54/src/climate_learn/data/dataset/args/shard_dataset_args.py#L28), etc was not optional.

So changed the default value to an empty dict. Thus calling `create_copy()` with no arguments would result in exact same copy.