### PR TITLE
Enforced data dtype in ERA5 to np.float32

### DIFF
--- a/src/climate_learn/data/climate_dataset/climate_dataset.py
+++ b/src/climate_learn/data/climate_dataset/climate_dataset.py
@@ -3,7 +3,7 @@ from abc import ABC
 from typing import Any, Callable, Dict, Sequence, Tuple, Union
 
 # Third party
-import numpy
+import numpy as np
 import torch
 
 # Local application
@@ -58,7 +58,7 @@ class ClimateDataset(ABC):
     def get_constants_data(self) -> Dict[str, torch.tensor]:
         raise NotImplementedError
 
-    def get_time(self) -> Union[numpy.ndarray, None]:
+    def get_time(self) -> Union[np.ndarray, None]:
         raise NotImplementedError
 
     def get_metadata(self) -> Dict[str, Any]:

--- a/src/climate_learn/data/climate_dataset/era5/era5.py
+++ b/src/climate_learn/data/climate_dataset/era5/era5.py
@@ -6,7 +6,7 @@ import random
 from typing import Callable, Dict, Iterable, Sequence, Tuple, Union
 
 # Third party
-import numpy
+import numpy as np
 import torch
 from tqdm import tqdm
 import xarray as xr
@@ -31,9 +31,9 @@ class ERA5(ClimateDataset):
         super().__init__(data_args)
         self.root_dir: str = data_args.root_dir
         self.years: Iterable[int] = data_args.years
-        self.lat: Union[numpy.ndarray, None] = None
-        self.lon: Union[numpy.ndarray, None] = None
-        self.time: Union[numpy.ndarray, None] = None
+        self.lat: Union[np.ndarray, None] = None
+        self.lon: Union[np.ndarray, None] = None
+        self.time: Union[np.ndarray, None] = None
         self.variables_map: Dict[str, Sequence[str]] = {}
         self.build_variables_map()
         self.constants_data: Dict[str, torch.tensor] = {}
@@ -92,7 +92,7 @@ class ERA5(ClimateDataset):
             all_constants = xr.open_mfdataset(ps, combine="by_coords")
             for name in self.constants:
                 self.constants_data[name] = torch.tensor(
-                    all_constants[NAME_TO_VAR[name]].values.astype(numpy.float32)
+                    all_constants[NAME_TO_VAR[name]].values.astype(np.float32)
                 )
 
     def initialize_data_dict(self) -> Dict[str, Sequence]:
@@ -134,7 +134,7 @@ class ERA5(ClimateDataset):
         # using next(iter) isntead of list(data_dict.keys())[0] to get random element
         self.time = data_dict[next(iter(data_dict.keys()))].time.values
         data_dict: Dict[str, torch.tensor] = {
-            k: torch.from_numpy(data_dict[k].values.astype(numpy.float32))
+            k: torch.from_numpy(data_dict[k].values.astype(np.float32))
             for k in data_dict.keys()
         }
         return data_dict
@@ -242,12 +242,12 @@ class ERA5(ClimateDataset):
     ) -> Dict[str, torch.tensor]:  # Dict where each value is a torch tensor shape 32*64
         return self.constants_data
 
-    def get_time(self) -> Union[numpy.ndarray, None]:
+    def get_time(self) -> Union[np.ndarray, None]:
         return self.time
 
     def get_metadata(
         self,
-    ) -> Dict[str, Union[numpy.ndarray, None]]:  # Dict where each value is a ndarray
+    ) -> Dict[str, Union[np.ndarray, None]]:  # Dict where each value is a ndarray
         return {"lat": self.lat, "lon": self.lon}
 
 

--- a/src/climate_learn/data/climate_dataset/era5/era5.py
+++ b/src/climate_learn/data/climate_dataset/era5/era5.py
@@ -92,7 +92,7 @@ class ERA5(ClimateDataset):
             all_constants = xr.open_mfdataset(ps, combine="by_coords")
             for name in self.constants:
                 self.constants_data[name] = torch.tensor(
-                    all_constants[NAME_TO_VAR[name]].values
+                    all_constants[NAME_TO_VAR[name]].values.astype(numpy.float32)
                 )
 
     def initialize_data_dict(self) -> Dict[str, Sequence]:
@@ -134,7 +134,8 @@ class ERA5(ClimateDataset):
         # using next(iter) isntead of list(data_dict.keys())[0] to get random element
         self.time = data_dict[next(iter(data_dict.keys()))].time.values
         data_dict: Dict[str, torch.tensor] = {
-            k: torch.from_numpy(data_dict[k].values) for k in data_dict.keys()
+            k: torch.from_numpy(data_dict[k].values.astype(numpy.float32))
+            for k in data_dict.keys()
         }
         return data_dict
 

--- a/src/climate_learn/data/climate_dataset/stacked_climate_dataset.py
+++ b/src/climate_learn/data/climate_dataset/stacked_climate_dataset.py
@@ -2,7 +2,7 @@
 from typing import Callable, Dict, Sequence, Tuple, Union
 
 # Third party
-import numpy
+import numpy as np
 import torch
 
 # Local application
@@ -59,9 +59,9 @@ class StackedClimateDataset(ClimateDataset):
     def get_constants_data(self) -> Sequence[Dict[str, torch.tensor]]:
         return [dataset.get_constants_data() for dataset in self.climate_datasets]
 
-    def get_time(self) -> Union[numpy.ndarray, None]:
+    def get_time(self) -> Union[np.ndarray, None]:
         ## Assuming that all datasets have same time
-        time: numpy.ndarray = self.climate_datasets[0].get_time()
+        time: np.ndarray = self.climate_datasets[0].get_time()
         isNone: bool = False
         for climate_dataset in self.climate_datasets:
             if climate_dataset.get_time() is None:
@@ -73,7 +73,7 @@ class StackedClimateDataset(ClimateDataset):
                 )
         return time
 
-    def get_metadata(self) -> Sequence[Dict[str, numpy.ndarray]]:
+    def get_metadata(self) -> Sequence[Dict[str, np.ndarray]]:
         return [dataset.get_metadata() for dataset in self.climate_datasets]
 
 

--- a/src/climate_learn/data/dataset/map_dataset.py
+++ b/src/climate_learn/data/dataset/map_dataset.py
@@ -2,7 +2,7 @@
 from typing import Callable, Dict, Sequence, Tuple, Union
 
 # Third party
-import numpy
+import numpy as np
 import torch
 from torch.utils.data import Dataset
 from torchvision.transforms import transforms
@@ -38,10 +38,10 @@ class MapDataset(Dataset):
             task_class: Callable[..., Task] = dataset_args.task_args._task_class
         self.task: Task = task_class(dataset_args.task_args)
 
-        self.lat: Union[numpy.ndarray, None] = None
-        self.lon: Union[numpy.ndarray, None] = None
-        self.out_lat: Union[numpy.ndarray, None] = None
-        self.out_lon: Union[numpy.ndarray, None] = None
+        self.lat: Union[np.ndarray, None] = None
+        self.lon: Union[np.ndarray, None] = None
+        self.out_lat: Union[np.ndarray, None] = None
+        self.out_lon: Union[np.ndarray, None] = None
         self.length: int = 0
         self.climatology: Union[Data, None] = None
 
@@ -155,11 +155,11 @@ class MapDataset(Dataset):
             const = None
         return inp, out, const
 
-    def get_time(self) -> numpy.ndarray:
+    def get_time(self) -> np.ndarray:
         time_indices: Sequence[int] = [
             self.task.get_time_index(index) for index in range(self.length)
         ]
-        time: Union[None, numpy.ndarray] = self.data.get_time()
+        time: Union[None, np.ndarray] = self.data.get_time()
         if time == None:
             raise RuntimeError(f"No data has been loaded into the memory yet.")
         return time[time_indices]

--- a/src/climate_learn/data/dataset/shard_dataset.py
+++ b/src/climate_learn/data/dataset/shard_dataset.py
@@ -3,7 +3,7 @@ import random
 from typing import Callable, Dict, Sequence, Tuple, Union
 
 # Third party
-import numpy
+import numpy as np
 import torch
 from torch.utils.data import IterableDataset
 from torchvision.transforms import transforms
@@ -38,10 +38,10 @@ class ShardDataset(IterableDataset):
         self.task: Task = task_class(dataset_args.task_args)
         self.n_chunks = dataset_args.n_chunks
 
-        self.lat: Union[numpy.ndarray, None] = None
-        self.lon: Union[numpy.ndarray, None] = None
-        self.out_lat: Union[numpy.ndarray, None] = None
-        self.out_lon: Union[numpy.ndarray, None] = None
+        self.lat: Union[np.ndarray, None] = None
+        self.lon: Union[np.ndarray, None] = None
+        self.out_lat: Union[np.ndarray, None] = None
+        self.out_lon: Union[np.ndarray, None] = None
         self.climatology: Union[Data, None] = None
         self.epoch: int = 0
 
@@ -138,7 +138,7 @@ class ShardDataset(IterableDataset):
 
         ### Using https://math.stackexchange.com/a/37131 to calculate mean and std from chunk mean and std
         # GCD used to prevent any numerical overflow
-        length_gcd: int = numpy.gcd.reduce(
+        length_gcd: int = np.gcd.reduce(
             [chunk_data[4] for chunk_data in transform_data]
         )
         reduced_total_length: torch.tensor = torch.tensor(0.0)
@@ -288,7 +288,7 @@ class ShardDataset(IterableDataset):
             const = None
         return inp, out, const
 
-    def get_time(self) -> numpy.ndarray:
+    def get_time(self) -> np.ndarray:
         raise NotImplementedError
 
     def get_transforms(self) -> Tuple[Transform, Transform, Transform]:


### PR DESCRIPTION
The current way of creating `torch.tensor` (for `ERA5`) from the `xarray` data loaded from `netcdf` files is [`this`](https://github.com/aditya-grover/climate-learn/blob/4b3d58821f889921014d7af2a1e49140b0f756a5/src/climate_learn/data/climate_dataset/era5/era5.py#L136).

This works fine for most cases except a few variables like [`"latitude"`](https://github.com/aditya-grover/climate-learn/blob/4b3d58821f889921014d7af2a1e49140b0f756a5/src/climate_learn/data/climate_dataset/era5/constants.py#L45) which are stored as `double` instead of `float`.

The previous versions of climate-learn took care of this issue by enforcing the type of the numpy array as float32 (See [`this`](https://github.com/aditya-grover/climate-learn/blob/58829c2da619803101fc202d3fd8fe85f3065544/src/climate_learn/data/tasks/forecasting.py#L34)). I never realized it's necessity back then.

**Why is this an issue?**
Having a single variable stored as double converts the entire `torch.tensor` as `double`. This then results in a batch where input and output are in `double` but the model takes input as `float`, thus it throws an error. For some-reason, if the data is stored in `float32` and then `precision` is set to `16`, either the PyTorch or pytorch-lightning automatically deals with the conversion from `float32` to `float16`. So enforcing `float32` is not an issue.