### PR TITLE
Fixed bug in building years to iterate for a given load_chunk() call …

### DIFF
--- a/src/climate_learn/data/climate_dataset/era5/era5.py
+++ b/src/climate_learn/data/climate_dataset/era5/era5.py
@@ -220,11 +220,18 @@ class ERA5(ClimateDataset):
         return -1, self.variables_to_update_for_task()
 
     def load_chunk(self, chunk_id: int) -> int:
-        n_years_in_chunk: int = (
-            len(self.years_to_iterate) + self.n_chunks - 1
-        ) // self.n_chunks
+        n_years_in_chunk: int = len(self.years_to_iterate) // self.n_chunks
+        n_chunks_with_extra_year: int = len(self.years_to_iterate) % self.n_chunks
+        offset: int = 0
+        if chunk_id >= n_chunks_with_extra_year:
+            offset = n_chunks_with_extra_year * (n_years_in_chunk + 1)
+            chunk_id = chunk_id - n_chunks_with_extra_year
+        else:
+            n_years_in_chunk = n_years_in_chunk + 1
         years_to_iterate_this_chunk = self.years_to_iterate[
-            chunk_id * n_years_in_chunk : (chunk_id + 1) * n_years_in_chunk
+            offset
+            + chunk_id * n_years_in_chunk : offset
+            + (chunk_id + 1) * n_years_in_chunk
         ]
         self.data_dict = self.load_from_nc_by_years(
             self.root_dir, years_to_iterate_this_chunk

--- a/src/climate_learn/data/dataset/shard_dataset.py
+++ b/src/climate_learn/data/dataset/shard_dataset.py
@@ -44,6 +44,8 @@ class ShardDataset(IterableDataset):
         self.out_lon: Union[np.ndarray, None] = None
         self.climatology: Union[Data, None] = None
         self.epoch: int = 0
+        self.shuffle: bool = True
+        self.drop_last: bool = False
 
     def get_setup_args(self, seed: int) -> Dict[str, int]:
         setup_args: Dict[str, int] = {}
@@ -78,8 +80,10 @@ class ShardDataset(IterableDataset):
         setup_args["rank"] = rank
         setup_args["seed"] = seed
         setup_args["n_chunks"] = self.n_chunks
-        setup_args["shuffle"] = True
-        setup_args["drop_last"] = True
+        if self.drop_last:
+            setup_args["drop_last"] = True
+        if self.shuffle:
+            setup_args["shuffle"] = True
         return setup_args
 
     def setup_transforms(self) -> None:
@@ -239,6 +243,7 @@ class ShardDataset(IterableDataset):
 
     def setup(self) -> None:
         setup_args: Dict[str, int] = self.get_setup_args(seed=0)
+        del setup_args["shuffle"]
         data_len, variables_to_update = self.data.setup(
             style="shard", setup_args=setup_args
         )


### PR DESCRIPTION
Fixed bug in building years to iterate for a given load_chunk() call for Shard Dataset.

Earlier for some situations/configurations the `years_to_iterate_this_chunk` had `0` number of years for last chunk.