### PR TITLE
Fix `nc2npz.py` for processing constants fields.

### DIFF
--- a/src/climate_learn/data/processing/era5_constants.py
+++ b/src/climate_learn/data/processing/era5_constants.py
@@ -70,6 +70,7 @@ VAR_TO_UNIT = {
 
 DEFAULT_PRESSURE_LEVELS = [50, 250, 500, 600, 700, 850, 925]
 
+CONSTANT_VARS = ["orography", "lsm", "slt", "lat2d", "lon2d"]
 CONSTANTS = ["orography", "land_sea_mask", "slt", "lattitude", "longitude"]
 
 NAME_LEVEL_TO_VAR_LEVEL = {}

--- a/src/climate_learn/data/processing/nc2npz.py
+++ b/src/climate_learn/data/processing/nc2npz.py
@@ -13,7 +13,7 @@ from .era5_constants import (
     DEFAULT_PRESSURE_LEVELS,
     NAME_TO_VAR,
     VAR_TO_NAME,
-    CONSTANTS,
+    CONSTANT_VARS,
 )
 
 HOURS_PER_YEAR = 8736  # 8760 --> 8736 which is dividable by 16
@@ -27,14 +27,14 @@ def nc2np(path, variables, years, save_dir, partition, num_shards_per_year):
         normalize_std = {}
     climatology = {}
 
-    constants_path = os.path.join(path, "constants.nc")
+    constants_path = os.path.join(path, "constants/constants.nc")
     constants_are_downloaded = os.path.isfile(constants_path)
 
     if constants_are_downloaded:
         constants = xr.open_mfdataset(
             constants_path, combine="by_coords", parallel=True
         )
-        constant_fields = [VAR_TO_NAME[v] for v in CONSTANTS if v in VAR_TO_NAME.keys()]
+        constant_fields = [VAR_TO_NAME[v] for v in CONSTANT_VARS if v in VAR_TO_NAME.keys()]
         constant_values = {}
         for f in constant_fields:
             constant_values[f] = np.expand_dims(


### PR DESCRIPTION
There seemed to be two issues with `nc2npz.py`

1. The constants seem to be downloaded into `constants/constants.nc`, rather than just `./constants.nc`, so they're in a subdirectory.
2. The `CONSTANTS` list was not using the nc variables names. It looks like CONSTANTS is used elsewhere, so I added `CONSTANT_VARS`, which uses the nc variable names. 

I think this fixes my issue #125.