### PR TITLE
Fix old keyword being used in module loaders

### DIFF
--- a/experiments/downscaling/era5_era5_baselines.py
+++ b/experiments/downscaling/era5_era5_baselines.py
@@ -30,8 +30,8 @@ dm = cl.data.IterDataModule(
 dm.setup()
 
 # Set up baseline models
-nearest = cl.load_downscaling_module(data_module=dm, preset="nearest-interpolation")
-bilinear = cl.load_downscaling_module(data_module=dm, preset="bilinear-interpolation")
+nearest = cl.load_downscaling_module(data_module=dm, architecture="nearest-interpolation")
+bilinear = cl.load_downscaling_module(data_module=dm, architecture="bilinear-interpolation")
 
 # Evaluate baselines (no training needed)
 trainer = pl.Trainer()

--- a/experiments/downscaling/era5_prism_baselines.py
+++ b/experiments/downscaling/era5_prism_baselines.py
@@ -27,14 +27,14 @@ denorm = Denormalize(dm)
 denorm_mask = lambda x: denorm(mask(x))
 nearest = cl.load_downscaling_module(
     data_module=dm,
-    preset="nearest-interpolation",
+    architecture="nearest-interpolation",
     train_target_transform=mask,
     val_target_transform=[denorm_mask, denorm_mask, denorm_mask, mask],
     test_target_transform=[denorm_mask, denorm_mask, denorm_mask],
 )
 bilinear = cl.load_downscaling_module(
     data_module=dm,
-    preset="bilinear-interpolation",
+    architecture="bilinear-interpolation",
     train_target_transform=mask,
     val_target_transform=[denorm_mask, denorm_mask, denorm_mask, mask],
     test_target_transform=[denorm_mask, denorm_mask, denorm_mask],

--- a/experiments/forecasting/cmip6_cmip6_baselines.py
+++ b/experiments/forecasting/cmip6_cmip6_baselines.py
@@ -30,8 +30,8 @@ dm = cl.data.IterDataModule(
 dm.setup()
 
 # Set up baseline models
-climatology = cl.load_forecasting_module(data_module=dm, preset="climatology")
-persistence = cl.load_forecasting_module(data_module=dm, preset="persistence")
+climatology = cl.load_forecasting_module(data_module=dm, architecture="climatology")
+persistence = cl.load_forecasting_module(data_module=dm, architecture="persistence")
 
 # Evaluate baslines (no training needed)
 trainer = pl.Trainer()

--- a/experiments/forecasting/era5_era5_baselines.py
+++ b/experiments/forecasting/era5_era5_baselines.py
@@ -30,8 +30,8 @@ dm = cl.data.IterDataModule(
 dm.setup()
 
 # Set up baseline models
-climatology = cl.load_forecasting_module(data_module=dm, preset="climatology")
-persistence = cl.load_forecasting_module(data_module=dm, preset="persistence")
+climatology = cl.load_forecasting_module(data_module=dm, architecture="climatology")
+persistence = cl.load_forecasting_module(data_module=dm, architecture="persistence")
 
 # Evaluate baslines (no training needed)
 trainer = pl.Trainer()

--- a/notebooks/MC_Dropout.ipynb
+++ b/notebooks/MC_Dropout.ipynb
@@ -107,7 +107,7 @@
     }
    ],
    "source": [
-    "model = cl.load_downscaling_module(data_module=dm, preset=\"resnet\")\n",
+    "model = cl.load_downscaling_module(data_module=dm, architecture=\"resnet\")\n",
     "checkpoint = \"../checkpoints/resnet_downscaling_t2m/checkpoints/last.ckpt\"\n",
     "model = cl.LitModule.load_from_checkpoint(checkpoint, net=model.net)"
    ]


### PR DESCRIPTION
There is a bug in the keywords from `cl.load_model_module` introduced [here](https://github.com/aditya-grover/climate-learn/pull/107), by renaming the [keyword](https://github.com/aditya-grover/climate-learn/blob/b48fb0242acc47e365af86bfbd9dd86e9dcbd6d2/src/climate_learn/utils/loaders.py#L31) from `preset` to `architecture`.

Under `/experiments` and `/notebooks`, the old keyword is still being used. For example:

```python
climatology = cl.load_forecasting_module(data_module=dm, preset="climatology")
```

found in [`experiments/forecasting/era5_era5_baselines.py`](https://github.com/aditya-grover/climate-learn/blob/b48fb0242acc47e365af86bfbd9dd86e9dcbd6d2/experiments/forecasting/era5_era5_baselines.py#L33)